### PR TITLE
Fix "Unable to Launch AltStore" when the app has no app-group container (NSCocoaError 512)

### DIFF
--- a/AltStoreCore/Model/DatabaseManager.swift
+++ b/AltStoreCore/Model/DatabaseManager.swift
@@ -454,8 +454,12 @@ private extension DatabaseManager
     
     func migrateDatabaseToAppGroupIfNeeded(completion: @escaping (Result<Void, Error>) -> Void)
     {
-        // Only migrate if we haven't migrated yet and there's a valid AltStore app group.
-        guard UserDefaults.shared.requiresAppGroupMigration && Bundle.main.altstoreAppGroup != nil else { return completion(.success(())) }
+        // Only migrate if we haven't migrated yet and there's a shared app-group container to migrate into.
+        // `altstoreAppGroup` alone isn't enough: it comes from Info.plist, which still lists the group
+        // when the app is signed without the app-group entitlement (e.g. free Apple IDs).
+        guard UserDefaults.shared.requiresAppGroupMigration,
+              Bundle.main.altstoreAppGroup != nil,
+              FileManager.default.altstoreSharedDirectory != nil else { return completion(.success(())) }
 
         func finish(_ result: Result<Void, Error>)
         {
@@ -508,8 +512,9 @@ private extension DatabaseManager
                     try FileManager.default.removeItem(at: previousDatabaseURL)
                 }
                 
-                // Migrate apps
-                if FileManager.default.fileExists(atPath: previousAppsDirectoryURL.path, isDirectory: nil)
+                // Migrate apps (skip if they're already in place).
+                if FileManager.default.fileExists(atPath: previousAppsDirectoryURL.path, isDirectory: nil),
+                   previousAppsDirectoryURL.standardizedFileURL != appsDirectoryURL.standardizedFileURL
                 {
                     _ = try FileManager.default.replaceItemAt(appsDirectoryURL, withItemAt: previousAppsDirectoryURL)
                 }


### PR DESCRIPTION
## Problem

AltStore signed with a free Apple ID fails to launch with "The file "Apps" couldn't be saved in the folder "Application Support"" (`NSCocoaErrorDomain 512`). The app-group migration only checks `Bundle.main.altstoreAppGroup`, which comes from Info.plist and is set even when the profile grants no app groups. With no shared container the source and destination paths are the same, so the migration deletes the live database and fails trying to move `Apps` onto itself.

## Fix

Skip the migration when `FileManager.altstoreSharedDirectory` is nil, and skip the `Apps` move when source and destination match.

## Testing

Reproduced on an iPhone with a free Apple ID on `classic`. With the fix the app launches, signs in, and installs and refreshes apps.

Fixes #833. Fixes #850.
