### PR TITLE
Integrate Classic sign-in recovery and SDK 26 UI compatibility

### DIFF
--- a/AltStore/Info.plist
+++ b/AltStore/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>ALTAppGroups</key>
 	<array>
 		<string>group.com.rileytestut.AltStore</string>


### PR DESCRIPTION
## Summary

This draft integrates a tested recovery for the recent Classic Apple ID sign-in/refresh failures reported in #1782 and #1776, where an HTML response from GrandSlam surfaces as `NSCocoaErrorDomain 3840`. It updates the shared AltSign dependency for both AltServer and the iPhone app, and opts the existing Classic interface into Apple's UI compatibility mode when built with the iOS 26 SDK. The reporter has confirmed the resulting recovery build **opens, signs in, installs apps, and refreshes apps** on the tested iPhone.

**Dependency:** [AltSign #53](https://github.com/rileytestut/AltSign/pull/53). This is a draft until maintainers decide how to integrate the AltSign work and validate the current Classic release build. The submodule URL remains the upstream `rileytestut/AltSign` URL; the proposed gitlink is `530e44aee968da15f8efe8d8eef829f3944ee318`. If the dependency is rebased or squash-merged, the gitlink must be updated before merging this PR.

## Background

### Scope and attribution

The target is **`classic`**, not the default Marketplace branch. The contribution does not claim to have discovered the outage or to fix every error that appears during Apple ID authentication.

It builds on:

- CircuitSerein's [connection-reuse investigation](https://github.com/altstoreio/AltStore/issues/1782#issuecomment-5558494372).
- BreezeDelegate's [AltSign User-Agent proposal #47](https://github.com/rileytestut/AltSign/pull/47), and Calvin-Zikakis's [notarized port #51](https://github.com/rileytestut/AltSign/pull/51).
- Calvin-Zikakis's [retry proposals #49](https://github.com/rileytestut/AltSign/pull/49) / [#50](https://github.com/rileytestut/AltSign/pull/50).
- sshane's [per-request session proposal #52](https://github.com/rileytestut/AltSign/pull/52).
- Other reports in #1782 that correctly distinguish a Mac-only workaround from replacing the iPhone app's authentication implementation.

The contribution adds an explicit exchange deadline, preserved structured Apple responses, body-free error reporting, reproducible tests, and an end-to-end recovery record. It is intended to complement or consolidate the existing proposals; it should not obscure their authorship.

### What failed

The visible authentication error included:

```text
NSCocoaErrorDomain 3840
Encountered unknown tag html on line 1
The data is not in the correct format.
```

The decisive response metadata from a failed installation was:

```text
init       HTTP 200  text/x-xml-plist
complete   HTTP 200  text/x-xml-plist
apptokens  HTTP 503  text/html
```

The parser error was a consequence of trying to parse an HTML error page as a property list. It was not evidence that the user had mistyped a password. A later 503 occurred even after using a separate session per request, so session isolation alone was insufficient on this setup.

The initial connection-reuse behavior was also reproduced by a credential-free local HTTP/1.1 fixture: two valid responses on one connection, then HTML 503. The old production method failed on exchange three; the isolated version used three connections and completed all exchanges. This validates the client-side mechanism without asserting a fixed global request limit or undocumented details of Apple's backend.

### Why both applications must change

The phone asks AltServer for anisette data, then invokes `ALTAppleAPI.authenticate` itself. AltServer returns that data; it does not perform the phone's SRP exchanges on the phone's behalf. Consequently:

- Updating the Mac can restore installation while leaving sign-in inside a stock iPhone app broken.
- Re-signing an official, unpatched IPA does not replace its compiled authentication implementation.
- Updating this shared dependency must be followed by rebuilding and distributing **both** application artifacts.

This is why the PR uses the shared AltSign gitlink rather than a Mac-only transport workaround.

## Changes

### 1. Shared authentication dependency

The linked AltSign contribution changes only the GsService2 transport and its User-Agent:

- Fresh ephemeral URLSession for every attempt, with explicit invalidation.
- Up to five total attempts, with 1/2/4/8-second backoff and a 20-second monotonic budget **per exchange**.
- Retries only for unstructured HTTP 500–599 responses.
- Structured Apple errors, successes, and challenges are interpreted before HTTP retry handling, including non-2xx envelopes.
- Cancellation, offline errors, 4xx responses, and malformed HTTP 200 responses do not trigger helper retries.
- Unrecoverable malformed responses produce a status-bearing error without response bodies or underlying parser details.

SRP cryptography, request parameters, anisette generation, two-factor code submission, and developer-portal operations are preserved. The 20-second limit is an operational choice for review, not a documented anisette lifetime.

### 2. Classic UI compatibility

The local rebuild used the iOS 26.5 SDK. After signing was corrected, the app reached permission prompts but aborted during UIKit safe-area/layout updates. Two reports agreed on a `swift_abortRetainUnowned` / `swift_unknownObjectUnownedLoadStrong` stack inside UIKitCore, followed by UIView layout frames.

Adding `UIDesignRequiresCompatibility = YES` was the final isolated configuration change before the reporter confirmed the app worked. It restores the older UI mode for the existing Classic interface rather than attempting an unrelated UI redesign in this authentication recovery.

Apple documents the key [here](https://developer.apple.com/documentation/bundleresources/information-property-list/uidesignrequirescompatibility). An Apple frameworks engineer [clarifies that Xcode 26-built apps honor it on iOS 26 and 27](https://developer.apple.com/forums/thread/838637). It is ignored when building with the iOS 27 SDK. This is therefore a **temporary compatibility measure**, not a permanent replacement for UI migration.

The exact UIKit ownership defect was not fully symbolicated or proven. The evidence supports the observed mitigation on the tested build; it does not establish that all startup crashes have this cause. This commit can be split out if maintainers prefer to review UI compatibility separately.

## Investigation history: what worked and what did not

The recovery began from an older local checkout, so several additional failures were specific to that build path. They are documented here to prevent them being confused with the outage or copied into current source unnecessarily.

| Attempt / observation | Outcome and lesson |
|---|---|
| Single-request probes returned a plist | Insufficient to test a multi-request connection-reuse failure. The three-exchange fixture exposed it. |
| Isolate GSA sessions only | Removed the deterministic reused-connection failure, but a later real install still returned HTML 503. Bounded retries and the modern User-Agent were added. |
| Rebuild AltServer only | Installation progressed, while stock AltStore on the phone still showed the format error. The iPhone authentication code also needed rebuilding. |
| Older AuthKit/XPC anisette helper | Returned no MID or OTP on the tested Mac. AOSKit returned nonempty fields; the upstream AOSKit implementation restored progress. This does not prove all `-80009` errors have that cause. |
| Strip/revisit signing entitlements as an explanation for MID rejection | Did not establish the cause. The decisive observation was the missing native-helper fields, not a guessed entitlement fix. |
| Old ldid from the historical checkout | The device rejected the signed app before startup with an AMFI hash-agility/CT-signature error. A local signing fixture showed a truncated SHA-256 value and a missing SHA-1 entry in the v2 CMS attribute. The newer upstream signer produced both full hashes. |
| Debug AltServer configuration | Selected a beta IPA. Release configuration was used to keep the stable bundle identity and tested 2.2.1 application. |
| Unsigned iPhone build used as an input artifact | Needed its original app/widget app-group entitlements retained before AltServer could re-provision it correctly. Ad-hoc input signing plus final AltServer signing was verified locally. |
| Rebuild the old UI with the current SDK | Triggered the UIKit startup abort described above. The compatibility flag was followed by the successful on-device report. |
| Package a patched IPA inside a local recovery installer | Avoided accidentally downloading the stock IPA again. This was a local delivery mechanism; the one-off installer, private paths, and binary payload are not included in this PR. |

The AOSKit and ldid changes already exist in current upstream history and are **not re-applied** here. Relevant provenance includes [the AOSKit implementation](https://github.com/altstoreio/AltStore/commit/cad9f90691e1ea295697a738ba9d48e2b9b8558e), [AltSign's ldid update](https://github.com/rileytestut/AltSign/commit/4746156408ca633bbfce4c267949053ca45886fe), and [Apple's full hash-agility validation](https://github.com/apple-oss-distributions/Security/blob/main/OSX/libsecurity_codesigning/lib/StaticCode.cpp).

## Testing

### Executed checks

| Check | Result |
|---|---|
| Original three-exchange transport fixture | Reproduced Cocoa error 3840 with an HTML 503 on the shared connection |
| Isolated-session fixture | Three successful exchanges on three connections |
| Final AltSign transport regression suite | **17 scenarios passed** on the exact contribution methods |
| Authentication source comparison | Complete PR auth file byte-for-byte matches the device-validated recovery auth source |
| Persistent-503 scenario | Exactly five attempts, approximately 16.1 seconds, inside the 20-second budget |
| Protocol/error scenarios | Structured credential/anisette errors and authentication challenges preserved; cancellation/offline/4xx/malformed-200 not retried |
| Privacy/completion scenarios | One observed completion per case; no body marker or underlying parser error exposed |
| Old/new signer fixture used during recovery | Old v2 hashes failed comparison; updated SHA-1/SHA-256 values matched the CodeDirectories and CMS verification passed |
| Recovery Mac and iPhone Release builds | Passed during the local recovery, including the final UI-compatibility rebuild |
| Packaged app/widget entitlements, ZIP integrity, and signature checks | Passed |
| `git diff --check` and staged-file security checks | Passed |
| Pending dependency gitlink | Fetched the exact commit from an empty repository through the unchanged upstream AltSign URL |

The portable suite is included in the AltSign dependency:

```sh
python3 Dependencies/AltSign/Tests/GrandSlamTransport/test_transport.py
```

It uses local HTTP fixtures and minimal Swift model/error shims around extracted production methods. It is not a live SRP test, does not validate every Apple error type's implementation, and does not contact Apple.

### Reporter-confirmed device result

On September 8, 2026, the reporter explicitly confirmed: **“Opens, signs in, and installs/refreshes apps.”**

Tested setup:

- iPhone 15 Pro, iOS 27.0.
- Apple Silicon Mac, macOS 26.5.2.
- Xcode 26.6, iPhoneOS 26.5 SDK.
- Recovery iPhone app based on the exact AltStore 2.2.1 (48) source revision `6538a9d6`.

This is a successful end-to-end report on one setup, not a claim of validation across all affected users, Windows, macOS 27, all Apple account types, or long-term unattended refreshes. The individual User-Agent effect was not isolated from the final transport changes in the live account test.

### Current integration-branch build limit

The code is proposed against current `classic` (`ad16c74c`), not by publishing the modified historical checkout. A clean current-branch build was attempted, but package resolution stopped because the pinned IDevice package expects `Dependencies/idevice/swift/IDevice.xcframework`, which was absent from the initialized source checkout. That build did **not** pass, and no substitute binary was fabricated. The current branch needs its normal generated IDevice artifact before maintainers can complete an integration release build.

The source changes have passing transport coverage and prior recovery-build/device evidence, but that does not substitute for a full current-branch release validation. This is one reason to keep the PR as a draft.

## Additional Notes

### How to integrate and validate

1. Review the companion AltSign transport implementation and tests; merge or consolidate it with the existing proposals.
2. Update this gitlink to the accepted upstream commit if its SHA changes. Keep the upstream submodule URL.
3. Initialize the pinned dependencies and provide the IDevice artifact required by the current Classic workspace. Run the transport suite above.
4. Build **AltServer and AltStore in Release configuration**, using the project's signing workflow. Preserve app and widget app-group entitlements when preparing an IPA for AltServer to re-sign. An unsigned compile-check bundle is not itself an installable release.
5. Install the rebuilt iPhone artifact, then verify launch, Apple ID sign-in, app installation, self-refresh, and another app's refresh. Confirm the UI compatibility behavior on the intended OS/SDK combinations.
6. Coordinate distribution of both artifacts. Updating AltServer's download flow to serve the existing stock IPA will leave its on-device authentication code unchanged; the release feed must point to the rebuilt iPhone app when maintainers publish it.

The local recovery did not require publishing or distributing a user's signing identity. No account passwords, tokens, certificates, provisioning profiles, UDIDs, raw crash reports, local installers, or IPA binaries are attached to this PR. Source and reproducible tests are provided; binary attachments can be considered separately if maintainers request them.

### Review notes

- This is AI-assisted work with executed local checks and explicit human on-device verification.
- The PR is intentionally transparent about the failed attempts, validation limits, existing authorship, and temporary UI workaround.
- Maintainer feedback is particularly useful on consolidating the AltSign proposals, the retry time budget, and whether the UI compatibility commit should be split.
