### PR TITLE
Fix Apple ID sign-in failing with HTTP 503 (Apple blocks the hardcoded Xcode client identifier)

### DIFF
--- a/AltDaemon/AnisetteDataManager.swift
+++ b/AltDaemon/AnisetteDataManager.swift
@@ -56,7 +56,7 @@ struct AnisetteDataManager
                                            routingInfo: UInt64(headers["X-Apple-I-MD-RINFO"] ?? "") ?? 0,
                                            deviceUniqueIdentifier: device.uniqueDeviceIdentifier,
                                            deviceSerialNumber: device.serialNumber,
-                                           deviceDescription: "<MacBookPro15,1> <Mac OS X;10.15.2;19C57> <com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>",
+                                           deviceDescription: "<MacBookPro15,1> <Mac OS X;10.15.2;19C57> <com.apple.AuthKit/1 (com.apple.akd/1.0)>",
                                            date: date,
                                            locale: .current,
                                            timeZone: .current)

--- a/AltServer/Anisette Data/AnisetteDataManager.swift
+++ b/AltServer/Anisette Data/AnisetteDataManager.swift
@@ -25,7 +25,7 @@ private extension ALTAnisetteData
         guard let range = self.deviceDescription.lowercased().range(of: "(" + bundleID.lowercased()) else { return }
         
         var adjustedDescription = self.deviceDescription[..<range.lowerBound]
-        adjustedDescription += "(com.apple.dt.Xcode/3594.4.19)>"
+        adjustedDescription += "(com.apple.akd/1.0)>"
         
         self.deviceDescription = String(adjustedDescription)
     }
@@ -162,7 +162,7 @@ private extension AnisetteDataManager
             let deviceModel = ProcessInfo.processInfo.deviceModel ?? "iMac21,1"
             let osName = (osVersion.majorVersion < 11) ? "Mac OS X" : "macOS"
             
-            let serverFriendlyDescription = "<\(deviceModel)> <\(osName);\(osVersion.stringValue);\(buildVersion)> <com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>"
+            let serverFriendlyDescription = "<\(deviceModel)> <\(osName);\(osVersion.stringValue);\(buildVersion)> <com.apple.AuthKit/1 (com.apple.akd/1.0)>"
             
             let anisetteData = ALTAnisetteData(machineID: machineID,
                                                oneTimePassword: oneTimePassword,


### PR DESCRIPTION
## Problem

Since early September 2026 every Apple ID sign-in fails with:

> AltServer could not sign in with your Apple ID.
> Apple's authentication servers returned an error (HTTP 503).

Nobody can install or refresh AltStore. The error message blames Apple, and it is
half right: Apple's authentication edge now refuses any request whose
`X-MMe-Client-Info` header identifies the client as Xcode. That identifier is
hardcoded in this repo, so the request is rejected before any credential is checked —
it fails identically with a nonexistent account.

## Root cause

`POST https://gsa.apple.com/grandslam/GsService2` is refused at the edge (190-byte
HTML page from `Server: Apple`, ~0.2s, not a real GSA plist) whenever
`X-MMe-Client-Info` contains the substring `com.apple.dt.Xcode`.

Isolated by elimination — none of these affect the outcome:

- **Version bump.** `com.apple.dt.Xcode/9999.9.99`, `/23500`, `/1.0` → all 503. The
  block is on `com.apple.dt.Xcode`, not the version.
- **User-Agent.** `akd/1.0 CFNetwork/808.1.4`, `/978.0.7`, `/1568.100.1`, `curl/8.7.1`
  and a browser UA → all 503.
- **Hardware/OS portion of the header**, HTTP version, connection reuse, and which of
  Apple's five edge IPs is used → no effect.

Only the client token matters:

| `X-MMe-Client-Info` client token | HTTP | Response |
|---|---|---|
| `com.apple.dt.Xcode/3594.4.19` | 503 | HTML error page, dropped at edge |
| `com.apple.akd/1.0` | 200 | GSA plist, `ec=-20101 "Your account information was entered incorrectly."` |

The 200 used a well-formed SRP `init` plist with real anisette data and a deliberately
nonexistent account, so `-20101` is the correct answer and confirms the request now
reaches the authentication service.

## Fix

Report the client as `akd`, the daemon that actually performs this request on macOS,
in the three places the identifier is hardcoded:

- `AltServer/Anisette Data/AnisetteDataManager.swift:28` — `sanitize(byReplacingBundleID:)`
- `AltServer/Anisette Data/AnisetteDataManager.swift:165` — `serverFriendlyDescription`
- `AltDaemon/AnisetteDataManager.swift:59` — hardcoded `deviceDescription`

## Verify

```
# prints 503
curl -s -o /dev/null -w "%{http_code}\n" -X POST \
  -H 'X-MMe-Client-Info: <Mac14,2> <macOS;15.7.5;24G624> <com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>' \
  --data-binary t https://gsa.apple.com/grandslam/GsService2

# prints 401 — reaches the service instead of being dropped
curl -s -o /dev/null -w "%{http_code}\n" -X POST \
  -H 'X-MMe-Client-Info: <Mac14,2> <macOS;15.7.5;24G624> <com.apple.AuthKit/1 (com.apple.akd/1.0)>' \
  --data-binary t https://gsa.apple.com/grandslam/GsService2
```

## Testing

**Not compiled.** Xcode is not installed on the machine this was written on, so the
project could not be built or run through its test suite. The change is three string
literals with no type or control-flow impact, but please build before merging.

End-to-end, on the shipping binary rather than this build: the same substitution was
applied to the four occurrences of the literal inside AltServer 1.7.5 (build 92) on
macOS 15.7.5, and a full sign-in, AltStore install and AltStore update then completed
successfully on a real iPhone.

One caveat, stated plainly: that binary patch had to preserve byte length, so it used
`com.apple.accountsd/113.0.11` (28 bytes, same as the original) rather than
`com.apple.akd/1.0`. Both return HTTP 200 with a valid GSA plist, so they are equivalent
at the point of failure, but the complete install flow was exercised with the
`accountsd` variant. Source has no length constraint, hence `akd` here.

## Notes for maintainers

- Third-party anisette servers commonly serve this same stale Xcode string and are
  blocked for the same reason. They need the same change independently.
- Windows AltServer was not examined; if it carries the same literal it needs the same fix.
- This treats the symptom. Apple could block `com.apple.akd/1.0` next; the durable fix
  is to derive the identifier from the system instead of hardcoding it. Left out of this
  PR to keep the diff to the bug.
- The literal stays duplicated across two targets that share no common file. Extracting
  a shared constant felt like it belonged in a separate change.
